### PR TITLE
fixed: params with '#' character

### DIFF
--- a/src/FileUpload.js
+++ b/src/FileUpload.js
@@ -283,7 +283,7 @@ const FileUpload = React.createClass({
             const paramArr = []
             param['_'] = mill
             Object.keys(param).forEach(key =>
-              paramArr.push(`${key}=${param[key]}`)
+              paramArr.push(`${key}=${encodeURIComponent(param[key])}`)
             )
             paramStr = '?' + paramArr.join('&')
         }
@@ -410,7 +410,7 @@ const FileUpload = React.createClass({
             param['_'] = mill
             param['ie'] === undefined && (param['ie'] = 'true')
             for (const key in param) {
-                if(param[key] != undefined) paramArr.push(`${key}=${param[key]}`)
+                if(param[key] != undefined) paramArr.push(`${key}=${encodeURIComponent(param[key])}`)
             }
             paramStr = '?' + paramArr.join('&')
         }


### PR DESCRIPTION
params的value包含`#`字符时，后面的参数会被忽略，例如：`param: { p: '#a', q: 'test' }`，p里的a会被忽略，后面的q也会被忽略，需要encode一下